### PR TITLE
updater: Support loading dynamic partition metadata from OTA

### DIFF
--- a/edify/include/edify/updater_runtime_interface.h
+++ b/edify/include/edify/updater_runtime_interface.h
@@ -72,7 +72,8 @@ class UpdaterRuntimeInterface {
   // Dynamic partition related functions.
   virtual bool MapPartitionOnDeviceMapper(const std::string& partition_name, std::string* path) = 0;
   virtual bool UnmapPartitionOnDeviceMapper(const std::string& partition_name) = 0;
-  virtual bool UpdateDynamicPartitions(const std::string_view op_list_value) = 0;
+  virtual bool UpdateDynamicPartitions(const std::string_view op_list_value,
+                                       const std::string_view super_empty_value) = 0;
 
   // On devices supports A/B, add current slot suffix to arg. Otherwise, return |arg| as is.
   virtual std::string AddSlotSuffix(const std::string_view arg) const = 0;

--- a/updater/include/updater/simulator_runtime.h
+++ b/updater/include/updater/simulator_runtime.h
@@ -52,7 +52,8 @@ class SimulatorRuntime : public UpdaterRuntimeInterface {
 
   bool MapPartitionOnDeviceMapper(const std::string& partition_name, std::string* path) override;
   bool UnmapPartitionOnDeviceMapper(const std::string& partition_name) override;
-  bool UpdateDynamicPartitions(const std::string_view op_list_value) override;
+  bool UpdateDynamicPartitions(const std::string_view op_list_value,
+                               const std::string_view super_empty_value) override;
   std::string AddSlotSuffix(const std::string_view arg) const override;
 
  private:

--- a/updater/include/updater/updater_runtime.h
+++ b/updater/include/updater/updater_runtime.h
@@ -22,6 +22,7 @@
 #include <utility>
 #include <vector>
 
+#include "edify/expr.h"
 #include "edify/updater_runtime_interface.h"
 
 class UpdaterRuntime : public UpdaterRuntimeInterface {
@@ -53,7 +54,8 @@ class UpdaterRuntime : public UpdaterRuntimeInterface {
 
   bool MapPartitionOnDeviceMapper(const std::string& partition_name, std::string* path) override;
   bool UnmapPartitionOnDeviceMapper(const std::string& partition_name) override;
-  bool UpdateDynamicPartitions(const std::string_view op_list_value) override;
+  bool UpdateDynamicPartitions(const std::string_view op_list_value,
+                               const std::string_view super_empty_value) override;
   std::string AddSlotSuffix(const std::string_view arg) const override;
 
   struct selabel_handle* sehandle() const override {

--- a/updater/simulator_runtime.cpp
+++ b/updater/simulator_runtime.cpp
@@ -113,7 +113,8 @@ bool SimulatorRuntime::UnmapPartitionOnDeviceMapper(const std::string& partition
   return true;
 }
 
-bool SimulatorRuntime::UpdateDynamicPartitions(const std::string_view op_list_value) {
+bool SimulatorRuntime::UpdateDynamicPartitions(const std::string_view op_list_value,
+                                               const std::string_view /* super_empty_value */) {
   const std::unordered_set<std::string> commands{
     "resize",    "remove",       "add",          "move",
     "add_group", "resize_group", "remove_group", "remove_all_groups",


### PR DESCRIPTION
* Provides an alternative option when dynamic partition metadata could not be loaded from the device (like when migrating from standard partitions to dynamic partitions)

Change-Id: I73381abd5b0cc1af37172a784735e25aae9c5958